### PR TITLE
initial dragging position fix

### DIFF
--- a/src/Calendar/Calendar.js
+++ b/src/Calendar/Calendar.js
@@ -39,6 +39,8 @@ function Calendar() {
    * }
   */
   const updateEvent = (e) => {
+    // Probably have to update the [hour] mapping if an event is dragged vertically 
+    // I don't think that's happening right now so it only updates when moving horizontally on drag
     if(e.hasOwnProperty("destination") && e.destination) {
       let draggableId = e.draggableId;
       let updatedEvent = '';

--- a/src/Calendar/utils.js
+++ b/src/Calendar/utils.js
@@ -77,8 +77,6 @@ export const generateWeekViewCoordinates = (event, startDate) => {
   }
 
   return {
-    top: top + '%',
-    left: left + '%',
     height: height + '%',
     width: width + '%',
   };

--- a/src/Calendar/weekView/components/CalendarEvent.js
+++ b/src/Calendar/weekView/components/CalendarEvent.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { Draggable } from "react-beautiful-dnd";
 import EventHighlighter from './EventHighlighter';
 
-function CalendarEvent ({ id, index, event, onEventDelete, onEventUpdate, startDate }) {
+function CalendarEvent({ id, index, event, onEventDelete, onEventUpdate, startDate }) {
     return (
         <Draggable draggableId={id} index={index} >
             {(provided, snapshot) => {
@@ -15,8 +15,8 @@ function CalendarEvent ({ id, index, event, onEventDelete, onEventUpdate, startD
                         })
                     );
                 }
-                return(
-                    <div ref={provided.innerRef} snapshot={snapshot} { ...provided.draggableProps } { ...provided.dragHandleProps }>
+                return (
+                    <div ref={provided.innerRef} snapshot={snapshot} {...provided.draggableProps} {...provided.dragHandleProps}>
                         <EventHighlighter
                             isDragging={snapshot.isDragging}
                             calendarPosition={index}

--- a/src/Calendar/weekView/components/TimeSlotGroup.js
+++ b/src/Calendar/weekView/components/TimeSlotGroup.js
@@ -34,7 +34,7 @@ function TimeSlotGroup ({ children, openAddEventModal, resources, time }) {
                     <div key={`${key}${time}n`} style={isTodaysDate(dateStamp) ? { ...lightHighlighter, "height": "100%" } : { "height": "100%" }}>
                         <button style={{ "width": "100%", "height": "100%", "background": "transparent", "border": "none", "cursor": "pointer", "outline": "none" }} onClick={() => openAddEventModal(key, time)} />
                     </div>
-                    {children}
+                    {children && children(resource.date)}
                     {provided.placeholder}
                   </div>
                 );

--- a/src/Calendar/weekView/components/WeekView.js
+++ b/src/Calendar/weekView/components/WeekView.js
@@ -5,16 +5,17 @@ import WeekToolbar from './WeekToolbar';
 import WeekHeader from './WeekHeader';
 import TimeSlotGroup from './TimeSlotGroup';
 import CalendarEvent from './CalendarEvent';
-import {times, getAllDaysInTheWeek} from '../../utils';
-import { v4 as uuidv4 } from 'uuid';
+import { times, getAllDaysInTheWeek } from '../../utils';
 import { DragDropContext } from "react-beautiful-dnd";
 
 function WeekView({ date, events, onNewEvent, onEventUpdate, onEventDelete }) {
+
   const [weekViewState, setWeekViewState] = useState('');
+
 
   useEffect(() => {
     let startDate = moment();
-    if(date) {
+    if (date) {
       startDate = moment(date);
     }
     setWeekViewState({
@@ -38,7 +39,7 @@ function WeekView({ date, events, onNewEvent, onEventUpdate, onEventDelete }) {
    * Sets next week days in the state
   */
   const goToNextWeek = () => {
-    const dateAfter7Days = moment(weekViewState.startDate).add (7, 'days');
+    const dateAfter7Days = moment(weekViewState.startDate).add(7, 'days');
     setWeekViewState({
       startDate: +dateAfter7Days,
       weekDays: getAllDaysInTheWeek(dateAfter7Days),
@@ -49,7 +50,7 @@ function WeekView({ date, events, onNewEvent, onEventUpdate, onEventDelete }) {
    * Sets previous week days in the state
   */
   const goToPreviousWeek = () => {
-    const dateBefore7Days = moment(weekViewState.startDate).subtract (7, 'days');
+    const dateBefore7Days = moment(weekViewState.startDate).subtract(7, 'days');
     setWeekViewState({
       startDate: +dateBefore7Days,
       weekDays: getAllDaysInTheWeek(dateBefore7Days),
@@ -61,7 +62,7 @@ function WeekView({ date, events, onNewEvent, onEventUpdate, onEventDelete }) {
    */
   const goToToday = () => {
     setWeekViewState({
-      startDate: +moment (),
+      startDate: +moment(),
       weekDays: getAllDaysInTheWeek(),
     });
   };
@@ -117,7 +118,7 @@ function WeekView({ date, events, onNewEvent, onEventUpdate, onEventDelete }) {
     });
   };
 
-  if(weekViewState) {
+  if (weekViewState) {
     return (
       <div>
         <AddEventModal
@@ -138,32 +139,36 @@ function WeekView({ date, events, onNewEvent, onEventUpdate, onEventDelete }) {
         <WeekHeader headerArray={weekViewState.weekDays} />
         <DragDropContext onDragEnd={onEventUpdate}>
           {times.map((time) => {
-            return(
+            return (
               <TimeSlotGroup
                 key={time}
                 time={time}
                 resources={weekViewState.weekDays}
                 openAddEventModal={openAddEventModal}
               >
-                {events[time] && events[time].map((event, index) => {
-                  if(event.startWeek <= moment(weekViewState.startDate).week() && event.endWeek >= moment(weekViewState.startDate).week()) {
-                    let id = uuidv4();
-                    Object.assign(event, { id });
-                    return(
-                      <CalendarEvent 
-                        key={id}
-                        id={id}
-                        index={index}
-                        event={{ ...event }}
-                        onEventDelete={onEventDelete}
-                        onEventUpdate={onEventUpdate}
-                        startDate={weekViewState.startDate}
-                      />
-                    );
-                  } else {
-                    return null;
+                {
+                  (date) => {
+                    return (
+                      <React.Fragment>
+                        {events[time] && events[time].map((event, index) => {
+                          if (event.startWeek <= moment(weekViewState.startDate).week() && event.endWeek >= moment(weekViewState.startDate).week() && moment(event.start).date() === date) {
+                            return (
+                              <CalendarEvent
+                                key={event.id}
+                                id={event.id}
+                                index={index}
+                                event={{ ...event }}
+                                onEventDelete={onEventDelete}
+                                onEventUpdate={onEventUpdate}
+                                startDate={weekViewState.startDate}
+                              />
+                            );
+                          }
+                        })}
+                      </React.Fragment>
+                    )
                   }
-                })}
+                }
               </TimeSlotGroup>
             );
           })}


### PR DESCRIPTION
Fix for the initial drag position going all the way to the end. 
The issue was caused because inside of the WeekView.js file there was multiple Events being rendered with the same id (it was hard to see because they were all right on top of each other). When a new event was added the WHOLE week had the same event rendered for every day. This was causing issues with the draggable (it basically made the start of the drag begin from the last day of the week instead of the one the use clicked on).

Issues still present:

- When adding an event the component renders 1 hour ahead even though the hour range is correct (this is an off by one error should be simple to fix probably just have to substract 1 from the hour check when rendering)
- You can't drag and drop vertically (I think for this one there is some logic missing inside of the updateEvent function in the Calendar component)